### PR TITLE
fix: cast --min-mapq to int in argparse

### DIFF
--- a/gapmm2/__main__.py
+++ b/gapmm2/__main__.py
@@ -65,6 +65,7 @@ def parse_args(args):
         "-m",
         "--min-mapq",
         dest="min_mapq",
+        type=int,
         default=1,
         help="minimum map quality value",
         metavar="",


### PR DESCRIPTION
## Bug

The `--min-mapq` option is declared without `type=int`, so CLI values are stored as strings. The subsequent comparison `if h.mapq < min_mapq` in `gapmm2/align.py` then raises:

```
TypeError: '<' not supported between instances of 'int' and 'str'
```

This crashes the splice aligner loop whenever `-m` is passed on the command line (including the default `-m 1` value that downstream wrappers like rectify pass via `subprocess`).

## Reproduce

Confirmed on **v23.11.3**, **v25.4.5**, and **v25.8.12** (master at 834ed20):

```bash
gapmm2 -t 2 -m 1 -i 5000 -o /tmp/out.paf <reference> <reads.fastq>
# → TypeError in splice_aligner; PAF is empty
```

Without `-m`, the default `default=1` (int) is used and the bug is masked. Any caller that passes `-m` explicitly hits it.

## Fix

One-line addition of `type=int,` to the `--min-mapq` argparse declaration, matching the neighbouring `--max-intron` option which already had it.

## Downstream impact

Multi-aligner pipelines that invoke `gapmm2` via `subprocess` with `-m <int>` (e.g. [RECTIFY](https://github.com/k-roy/RECTIFY)'s `rectify align --aligners all`) silently mark gapmm2 as failed and fall back to other aligners. This bug has been quietly suppressing the gapmm2 contribution to consensus selection for at least three releases.