### PR TITLE
ci: fix python-publish workflow and update CI Python matrix

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -52,6 +52,7 @@ jobs:
 
   publish-to-testpypi:
     name: Publish Python 🐍 distribution 📦 to TestPyPI
+    if: startsWith(github.ref, 'refs/tags/')  # only publish to TestPyPI on tag pushes
     needs:
     - build
     runs-on: ubuntu-latest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.10', '3.11', '3.12', '3.13']
 
     steps:
     - uses: actions/checkout@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
     "Intended Audience :: Science/Research",
     "Topic :: Scientific/Engineering :: Bio-Informatics",
 ]
-requires-python = ">=3.6.0"
+requires-python = ">=3.10"
 dependencies = [
     "mappy",
     "edlib",


### PR DESCRIPTION
Two CI/packaging fixes and one packaging-metadata bump.

## Why

The `python-publish` workflow has been failing on every push to `main` (most recent failure: [run 25980222917](https://github.com/nextgenusfs/gapmm2/actions/runs/25980222917) from the merge of #3). The `publish-to-pypi` job is correctly gated on tag pushes, but `publish-to-testpypi` has no such guard, so every non-tag push tries to republish the existing version to TestPyPI and gets a 400.

While I was in the workflows, I also bumped the `tests.yml` matrix off Python 3.8 (EOL 2024-10-31) and 3.9 (EOL 2025-10-31).

## Changes

- **`.github/workflows/python-publish.yml`**: add `if: startsWith(github.ref, 'refs/tags/')` to the `publish-to-testpypi` job, mirroring the existing guard on `publish-to-pypi`. The `build` job stays unguarded so it still validates the package builds on every push as a CI signal — only the publish jobs get skipped on non-tag pushes.
- **`.github/workflows/tests.yml`**: matrix changed from `['3.8', '3.9', '3.10', '3.11']` to `['3.10', '3.11', '3.12', '3.13']`.
- **`pyproject.toml`**: `requires-python` bumped from `">=3.6.0"` to `">=3.10"` to match the tested matrix floor. This is the only packaging-visible change — anyone on Python 3.6–3.9 will get a resolver error on the next release; both 3.8 and 3.9 are already EOL.

No runtime code in `gapmm2/` was touched. Action versions (`checkout@v4`, `setup-python@v5`, `upload/download-artifact@v4`, `codecov-action@v5`, `pypa/gh-action-pypi-publish@release/v1`) were already current and were not changed.

## Verification

- `pytest tests/ -q` → 16 passed in 0.06s (Python 3.11.15)
- Both workflow YAML files parse cleanly
- `git diff --stat`: 3 files changed, 3 insertions(+), 2 deletions(-)

The real proof for the publish-workflow fix comes after merge: the next non-tag push to `main` should show the publish jobs as **skipped** rather than **failed** in the Actions tab.

## Related

While investigating, I confirmed [issue #1](https://github.com/nextgenusfs/gapmm2/issues/1) (`AssertionError: Introns cannot be less than zero`) has been resolved since `v23.11.3` via the try/except wrappers in `gapmm2/align.py`. That issue can be closed separately — not part of this PR.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author